### PR TITLE
chore: nodenvで生成される.node-versionをGitの追跡から除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ prisma-script.ts
 
 # Prisma Script
 script/**.js
+
+# nodenv
+.node-version


### PR DESCRIPTION
nodenvで生成される`.node-version`をGitの追跡から除外するように設定。